### PR TITLE
Fix quotation marks being duplicated

### DIFF
--- a/lua/case_manager/init.lua
+++ b/lua/case_manager/init.lua
@@ -11,7 +11,7 @@ local to_snake = function(word, current_format)
     end
     if current_format == 'kebab' then
         local formatted_word = string.gsub(word, '%-', '_')
-        vim.cmd('normal! ciw' .. string.lower(formatted_word))
+        vim.cmd('normal! ciW' .. string.lower(formatted_word))
     end
 end
 
@@ -24,14 +24,14 @@ local to_camel = function(word, current_format)
             return string.upper(char)
         end)
         formatted_word = string.gsub(formatted_word, '%-', '')
-        vim.cmd('normal! ciw' .. formatted_word)
+        vim.cmd('normal! ciW' .. formatted_word)
     end
     if current_format == 'snake' then
         local formatted_word = string.gsub(word, '_[a-z]', function(char)
             return string.upper(char)
         end)
         formatted_word = string.gsub(formatted_word, '_', '')
-        vim.cmd('normal! ciw' .. formatted_word)
+        vim.cmd('normal! ciW' .. formatted_word)
     end
 end
 
@@ -45,7 +45,7 @@ local to_kebab = function(word, current_format)
     end
     if current_format == 'snake' then
         local formatted_word = string.gsub(word, '_', '-')
-        vim.cmd('normal! ciw' .. formatted_word)
+        vim.cmd('normal! ciW' .. formatted_word)
     end
 end
 

--- a/lua/case_manager/init.lua
+++ b/lua/case_manager/init.lua
@@ -11,7 +11,7 @@ local to_snake = function(word, current_format)
     end
     if current_format == 'kebab' then
         local formatted_word = string.gsub(word, '%-', '_')
-        vim.cmd('normal! ciW' .. string.lower(formatted_word))
+        vim.cmd('normal! ciw' .. string.lower(formatted_word))
     end
 end
 
@@ -24,14 +24,14 @@ local to_camel = function(word, current_format)
             return string.upper(char)
         end)
         formatted_word = string.gsub(formatted_word, '%-', '')
-        vim.cmd('normal! ciW' .. formatted_word)
+        vim.cmd('normal! ciw' .. formatted_word)
     end
     if current_format == 'snake' then
         local formatted_word = string.gsub(word, '_[a-z]', function(char)
             return string.upper(char)
         end)
         formatted_word = string.gsub(formatted_word, '_', '')
-        vim.cmd('normal! ciW' .. formatted_word)
+        vim.cmd('normal! ciw' .. formatted_word)
     end
 end
 
@@ -45,7 +45,7 @@ local to_kebab = function(word, current_format)
     end
     if current_format == 'snake' then
         local formatted_word = string.gsub(word, '_', '-')
-        vim.cmd('normal! ciW' .. formatted_word)
+        vim.cmd('normal! ciw' .. formatted_word)
     end
 end
 

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,7 +1,7 @@
 Manager = require('case_manager')
 
 Prompt = function(word)
-    return vim.ui.input({prompt = 'Enter new case ([s]nake, [c]amel, [k]ebab): '}, function(choice)
+    return vim.ui.input({prompt = 'Enter case ([s]nake, [c]amel, [k]ebab): '}, function(choice)
         Manager.convert(choice, word)
     end)
 end

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -6,4 +6,4 @@ Prompt = function(word)
     end)
 end
 
-vim.cmd([[ command! CaseManager :lua Prompt(vim.call('expand', '<cWORD>')) ]])
+vim.cmd([[ command! CaseManager :lua Prompt(vim.call('expand', '<cword>')) ]])

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -1,7 +1,7 @@
 Manager = require('case_manager')
 
 Prompt = function(word)
-    return vim.ui.input({prompt = 'Enter case ([s]nake, [c]amel, [k]ebab): '}, function(choice)
+    return vim.ui.input({prompt = 'Enter new case ([s]nake, [c]amel, [k]ebab): '}, function(choice)
         Manager.convert(choice, word)
     end)
 end


### PR DESCRIPTION
From what I can see a WORD includes the quotation marks when feeding it to the convert functions which then returns the converted string + quotes which vim automatically 'closes' with a matching quote?

Seemed like something similar was happening when using ciW instead of ciw when calling the vim commands.

Haven't really had the chance to tinker with vim plugins or lua yet as I've just been 'copying' a config video to set mine up so let me know if I've missed something (maybe ciW was needed for another reason?) 

:)
